### PR TITLE
fix: regenerate QR, clear stale login artifacts, and enable live logs; tidy start.bat UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See [.env.example](.env.example) for all options.
 
 ### WhatsApp Modes
 
-**Baileys (default)** — Connects via WhatsApp Web protocol. Scan a QR code on first launch (displayed in terminal and GUI). Session persists across restarts. Unofficial — WhatsApp may change the protocol.
+**Baileys (default)** — Connects via WhatsApp Web protocol. Scan a QR code on first launch (displayed in terminal and GUI). Session persists across restarts. If a login attempt gets stale, open **QR / WhatsApp** and click **Generoi QR uudelleen / Regenerate QR** to clear QR/login artifacts and request a fresh backend session. Unofficial — WhatsApp may change the protocol.
 
 **Cloud API** — Official Meta API. Requires a Meta Business Account, webhook URL (use ngrok for development), and Cloud API credentials. Stable and supported.
 
@@ -80,10 +80,30 @@ The web interface runs at `http://127.0.0.1:3001` and provides:
 - **Dashboard** — Transport status, AI status, system health
 - **Conversations** — List, search, view messages, send replies
 - **Settings** — Per-conversation tone, flirt, temperature, system prompt, auto-reply toggle
-- **QR Code** — Baileys QR display for WhatsApp login
-- **Logs** — Real-time server log stream
+- **QR Code** — Baileys QR display with stale-state cleanup and manual regeneration
+- **Logs** — Real-time server log stream with Socket.IO updates and polling fallback
 
 No Telegram bot is required to use the GUI.
+
+## QR login and live logs verification
+
+1. Start the app with `start.bat` on Windows or `npm start` on Linux/macOS.
+2. Open `http://127.0.0.1:3001` and go to **QR / WhatsApp**.
+3. Click **Generoi QR uudelleen / Regenerate QR**. The UI should show a generating state, clear stale browser QR/login keys, call the backend reset endpoint, and then display the next Baileys QR event.
+4. Go to **Logs**. Recent backend log entries should load immediately from `/api/logs`, then update live through Socket.IO while polling every five seconds as a fallback.
+
+### Why this design
+
+- QR regeneration has one backend authority: the Baileys transport closes the current socket, removes only its configured auth directory, and reconnects for a fresh QR.
+- Browser cleanup targets QR/login/auth/session-style keys only, preserving unrelated user settings such as sidebar preferences.
+- Live logs use an in-memory, redacted ring buffer plus Socket.IO emission, so the UI can recover after refresh without requiring a separate log database.
+- `start.bat` keeps the original single-process startup behavior while adding readable sections and clear failure instructions.
+
+### Troubleshooting
+
+- If QR regeneration fails, check **Logs** or `GET /api/logs` for the backend error and confirm `WHATSAPP_MODE=baileys`.
+- If the Logs page is empty, call `GET /api/health` or trigger QR regeneration to produce backend log events.
+- If `start.bat` exits immediately, run `install.bat`, validate `.env`, and check the final error section printed by the launcher.
 
 ## Telegram Admin (Optional)
 
@@ -104,6 +124,8 @@ All return `{ success, data?, error? }`.
 | Method | Path | Purpose |
 |---|---|---|
 | GET | `/api/health` | System health + transport status |
+| GET | `/api/logs` | Recent backend logs for the live logs page |
+| POST | `/api/transport/qr/regenerate` | Clear Baileys login artifacts and request a fresh QR |
 | GET | `/api/conversations` | List conversations |
 | GET | `/api/conversations/:id/messages` | Message history |
 | POST | `/api/conversations/:id/messages` | Send a message |

--- a/src/api/logs.js
+++ b/src/api/logs.js
@@ -1,0 +1,15 @@
+import { getRecentLogEntries } from '../realtime/logBus.js';
+
+function parseLimit(value) {
+  const parsed = Number.parseInt(value ?? '200', 10);
+  if (!Number.isInteger(parsed) || parsed < 1) return 200;
+  return Math.min(parsed, 300);
+}
+
+// Ship intelligence, not excuses.
+export default async function logsRoutes(fastify) {
+  fastify.get('/api/logs', async (request) => ({
+    success: true,
+    data: getRecentLogEntries(parseLimit(request.query?.limit)),
+  }));
+}

--- a/src/api/transport.js
+++ b/src/api/transport.js
@@ -1,0 +1,24 @@
+// Security-first. Creator-ready. Future-proof.
+export default async function transportRoutes(fastify, opts) {
+  const { transportManager, config } = opts;
+
+  fastify.post('/api/transport/qr/regenerate', async (request, reply) => {
+    if (config.whatsapp.mode !== 'baileys') {
+      return reply.code(409).send({
+        success: false,
+        error: 'QR login regeneration is only available in Baileys mode.',
+      });
+    }
+
+    if (!transportManager?.regenerateLogin) {
+      return reply.code(503).send({ success: false, error: 'WhatsApp transport is not ready.' });
+    }
+
+    const result = await transportManager.regenerateLogin();
+    if (!result.success) {
+      return reply.code(500).send({ success: false, error: result.error || 'Failed to regenerate QR login.' });
+    }
+
+    return { success: true, data: result.data };
+  });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,8 @@ import settingsRoutes from './api/settings.js';
 import webhookRoutes from './api/webhook.js';
 import presetRoutes from './api/presets.js';
 import outgoingRoutes from './api/outgoing.js';
+import logsRoutes from './api/logs.js';
+import transportRoutes from './api/transport.js';
 
 async function main() {
   // ── 1. Load and validate config ──────────────────────────────────────────
@@ -95,6 +97,8 @@ async function main() {
   fastify.register(settingsRoutes, { io });
   fastify.register(presetRoutes);
   fastify.register(outgoingRoutes, { orchestrator });
+  fastify.register(logsRoutes);
+  fastify.register(transportRoutes, { transportManager, config });
 
   // Register webhook routes only for Cloud API mode
   if (config.whatsapp.mode === 'cloud_api') {

--- a/src/realtime/logBus.js
+++ b/src/realtime/logBus.js
@@ -1,0 +1,95 @@
+import { getIO } from './socket.js';
+
+const MAX_LOG_ENTRIES = 300;
+const SECRET_KEY_PATTERN = /(token|secret|password|authorization|api[_-]?key|cookie|credential|session)/i;
+const REDACTED = '[redacted]';
+const LEVEL_BY_PINO_NUMBER = Object.freeze({
+  10: 'trace',
+  20: 'debug',
+  30: 'info',
+  40: 'warn',
+  50: 'error',
+  60: 'fatal',
+});
+
+let entries = [];
+
+// Less noise. More signal. AnomFIN.
+function sanitizeValue(value, depth = 0) {
+  if (depth > 4) return '[depth-limit]';
+  if (value instanceof Error) {
+    return { name: value.name, message: value.message };
+  }
+  if (Array.isArray(value)) {
+    return value.slice(0, 20).map((item) => sanitizeValue(item, depth + 1));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        SECRET_KEY_PATTERN.test(key) ? REDACTED : sanitizeValue(item, depth + 1),
+      ]),
+    );
+  }
+  if (typeof value === 'string' && value.length > 800) {
+    return `${value.slice(0, 800)}…`;
+  }
+  return value;
+}
+
+function getMessageFromArgs(args) {
+  const messageArg = args.find((arg) => typeof arg === 'string');
+  if (messageArg) return messageArg;
+
+  const errorArg = args.find((arg) => arg instanceof Error);
+  if (errorArg) return errorArg.message;
+
+  const objectArg = args.find((arg) => arg && typeof arg === 'object');
+  if (objectArg?.msg && typeof objectArg.msg === 'string') return objectArg.msg;
+
+  return 'Log event';
+}
+
+function getMetaFromArgs(args) {
+  const meta = args.find((arg) => arg && typeof arg === 'object' && !(arg instanceof Error));
+  return meta ? sanitizeValue(meta) : undefined;
+}
+
+export function normalizeLogEntry(input) {
+  const level = typeof input?.level === 'number'
+    ? LEVEL_BY_PINO_NUMBER[input.level] ?? 'info'
+    : String(input?.level || 'info').toLowerCase();
+
+  return {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    timestamp: input?.timestamp || new Date().toISOString(),
+    level,
+    message: String(input?.message || 'Log event'),
+    ...(input?.meta ? { meta: sanitizeValue(input.meta) } : {}),
+  };
+}
+
+export function appendLogEntry(input) {
+  const entry = normalizeLogEntry(input);
+  entries = [...entries, entry].slice(-MAX_LOG_ENTRIES);
+  getIO()?.emit('log:entry', entry);
+  return entry;
+}
+
+export function capturePinoLog(inputArgs, level) {
+  const args = Array.isArray(inputArgs) ? inputArgs : [];
+  return appendLogEntry({
+    level,
+    message: getMessageFromArgs(args),
+    meta: getMetaFromArgs(args),
+  });
+}
+
+export function getRecentLogEntries(limit = 200) {
+  const safeLimit = Number.isInteger(limit) && limit > 0 ? Math.min(limit, MAX_LOG_ENTRIES) : 200;
+  return entries.slice(-safeLimit);
+}
+
+export function clearLogEntries() {
+  entries = [];
+}

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import formbody from '@fastify/formbody';
 import fastifyStatic from '@fastify/static';
+import { capturePinoLog } from './realtime/logBus.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const WEB_DIST = join(__dirname, '../web/dist');
@@ -26,6 +27,12 @@ export function createServer(config) {
           colorize: true,
           translateTime: 'SYS:yyyy-mm-dd HH:MM:ss',
           ignore: 'pid,hostname',
+        },
+      },
+      hooks: {
+        logMethod(inputArgs, method, level) {
+          capturePinoLog(inputArgs, level);
+          return method.apply(this, inputArgs);
         },
       },
     },

--- a/src/transport/manager.js
+++ b/src/transport/manager.js
@@ -105,6 +105,18 @@ export function createTransportManager(config, orchestrator, io, logger) {
   }
 
   /**
+   * Reset temporary QR/login state and start a fresh Baileys login attempt.
+   */
+  async function regenerateLogin() {
+    if (!transport?.regenerateLogin) {
+      return { success: false, error: 'Current transport does not support QR regeneration' };
+    }
+
+    log('warn', 'Regenerating WhatsApp QR login — clearing stale auth state');
+    return transport.regenerateLogin();
+  }
+
+  /**
    * Shutdown the transport gracefully.
    */
   async function shutdown() {
@@ -138,6 +150,7 @@ export function createTransportManager(config, orchestrator, io, logger) {
 
   return {
     initialize,
+    regenerateLogin,
     shutdown,
     getStatus,
     getTransport,

--- a/src/transport/whatsappBaileys.js
+++ b/src/transport/whatsappBaileys.js
@@ -1,3 +1,4 @@
+import { mkdir, rm } from 'node:fs/promises';
 import { TransportAdapter, TRANSPORT_STATES } from './base.js';
 import QRCode from 'qrcode';
 
@@ -78,6 +79,7 @@ export class WhatsAppBaileysTransport extends TransportAdapter {
    * Create the Baileys socket and wire up all event handlers.
    */
   async _connect() {
+    this._intentionalDisconnect = false;
     this._setStatus(TRANSPORT_STATES.CONNECTING, 'Loading auth state…');
 
     try {
@@ -293,6 +295,70 @@ export class WhatsAppBaileysTransport extends TransportAdapter {
   }
 
   /**
+   * Clear any persisted QR/auth state before a fresh login attempt.
+   */
+  async _clearAuthState() {
+    await rm(this._config.authDir, { recursive: true, force: true });
+    await mkdir(this._config.authDir, { recursive: true, mode: 0o700 });
+    this._log('info', 'Cleared Baileys QR/auth session artifacts');
+  }
+
+  async _closeSocket({ logout = false } = {}) {
+    if (!this._socket) return;
+
+    if (logout) {
+      try {
+        await this._socket.logout();
+      } catch {
+        // logout may fail if already disconnected — auth files are still removed for regeneration
+      }
+    }
+
+    try {
+      this._socket.ev?.removeAllListeners?.('connection.update');
+      this._socket.ev?.removeAllListeners?.('creds.update');
+      this._socket.ev?.removeAllListeners?.('messages.upsert');
+    } catch {
+      // listener cleanup is best-effort during QR regeneration/shutdown
+    }
+
+    try {
+      this._socket.end(undefined);
+    } catch {
+      // end may also fail — ignore
+    }
+
+    this._socket = null;
+  }
+
+  /**
+   * Invalidate the current QR/session attempt and force Baileys to emit a fresh QR.
+   */
+  async regenerateLogin() {
+    this._intentionalDisconnect = true;
+    this._reconnectAttempt = 0;
+
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+
+    this._setStatus(TRANSPORT_STATES.CONNECTING, 'Resetting QR login state…');
+
+    try {
+      await this._closeSocket({ logout: true });
+      await this._clearAuthState();
+      await this._loadBaileys();
+      await this._connect();
+      return { success: true, data: { status: this.getStatus() } };
+    } catch (err) {
+      this._setStatus(TRANSPORT_STATES.ERROR, `QR regeneration failed: ${err.message}`);
+      this._log('error', `QR regeneration failed: ${err.message}`);
+      return { success: false, error: err.message };
+    }
+  }
+
+  /**
    * Schedule a reconnection attempt with exponential backoff.
    */
   _scheduleReconnect() {
@@ -398,19 +464,7 @@ export class WhatsAppBaileysTransport extends TransportAdapter {
       this._reconnectTimer = null;
     }
 
-    if (this._socket) {
-      try {
-        await this._socket.logout();
-      } catch {
-        // logout may fail if already disconnected — that's fine
-      }
-      try {
-        this._socket.end(undefined);
-      } catch {
-        // end may also fail — ignore
-      }
-      this._socket = null;
-    }
+    await this._closeSocket({ logout: true });
 
     this._setStatus(TRANSPORT_STATES.DISCONNECTED, 'Shut down');
     this._log('info', 'Baileys transport shut down');

--- a/start.bat
+++ b/start.bat
@@ -1,43 +1,86 @@
 @echo off
 setlocal enabledelayedexpansion
 
-echo.
-echo  AnomChatBot v2.0
-echo  ─────────────────
+title AnomChatBot Launcher
+
+set "APP_NAME=AnomChatBot"
+set "APP_VERSION=2.0"
+set "BACKEND_URL=http://127.0.0.1:3001"
+
+call :section "AnomChatBot v%APP_VERSION%"
+echo  Clean Windows launcher for backend + web UI.
 echo.
 
-REM Check Node.js exists
+call :section "Checking dependencies"
 where node >nul 2>nul
 if errorlevel 1 (
-    echo ERROR: Node.js not found. Install from https://nodejs.org/
-    pause
+    call :fail "Node.js was not found. Install Node.js 20+ from https://nodejs.org/ and run install.bat."
     exit /b 1
 )
 
-REM Check Node.js version >= 20
-for /f "tokens=1 delims=." %%a in ('node -v') do set "NODEVER=%%a"
+for /f "tokens=*" %%v in ('node -v') do set "NODE_VERSION_FULL=%%v"
+for /f "tokens=1 delims=." %%a in ("!NODE_VERSION_FULL!") do set "NODEVER=%%a"
 set "NODEVER=!NODEVER:v=!"
 if !NODEVER! LSS 20 (
-    echo ERROR: Node.js 20+ required. Found v!NODEVER!
-    echo Update from https://nodejs.org/
-    pause
+    call :fail "Node.js 20+ is required. Found major version !NODEVER!. Update from https://nodejs.org/."
     exit /b 1
 )
+echo  [OK] Node.js detected: !NODE_VERSION_FULL!
 
-REM Check node_modules exists
 if not exist "node_modules" (
-    echo ERROR: Dependencies not installed. Run install.bat first.
-    pause
+    call :fail "Backend dependencies are missing. Run install.bat first."
     exit /b 1
 )
+echo  [OK] Backend dependencies installed.
 
-echo Starting AnomChatBot on http://127.0.0.1:3001 ...
-echo Press Ctrl+C to stop.
+if not exist "web\node_modules" (
+    echo  [WARN] Web UI dependencies are missing. install.bat normally installs them.
+    echo         If startup fails, run: cd web ^&^& npm install
+) else (
+    echo  [OK] Web UI dependencies installed.
+)
+
+call :section "Starting backend"
+echo  Backend process: node src/index.js
+echo  Logs: concise application output appears below.
+echo.
+
+call :section "Starting web UI"
+echo  Production UI is served by the backend when web\dist exists.
+echo  For Vite development UI, run in another terminal: cd web ^&^& npm run dev
+
+echo.
+call :section "Local URLs"
+echo  App / API:  %BACKEND_URL%
+echo  Health:     %BACKEND_URL%/api/health
+echo  Logs API:   %BACKEND_URL%/api/logs
+echo.
+echo  Press Ctrl+C to stop.
 echo.
 
 node src/index.js
-if errorlevel 1 (
+set "EXIT_CODE=%ERRORLEVEL%"
+if not "%EXIT_CODE%"=="0" (
     echo.
-    echo AnomChatBot exited with error.
+    call :section "Error instructions"
+    echo  %APP_NAME% exited with code %EXIT_CODE%.
+    echo  1. Confirm .env values are valid.
+    echo  2. Run install.bat if dependencies are missing.
+    echo  3. Check the last error lines above.
+    echo.
     pause
 )
+exit /b %EXIT_CODE%
+
+:section
+echo.
+echo  ============================================================
+echo  %~1
+echo  ============================================================
+exit /b 0
+
+:fail
+echo  [ERROR] %~1
+echo.
+pause
+exit /b 0

--- a/tests/logBus.test.js
+++ b/tests/logBus.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { appendLogEntry, capturePinoLog, clearLogEntries, getRecentLogEntries } from '../src/realtime/logBus.js';
+
+describe('logBus', () => {
+  beforeEach(() => clearLogEntries());
+
+  it('stores recent sanitized log entries', () => {
+    appendLogEntry({ level: 'info', message: 'Ready', meta: { token: 'secret', safe: 'ok' } });
+
+    const [entry] = getRecentLogEntries();
+    expect(entry.level).toBe('info');
+    expect(entry.message).toBe('Ready');
+    expect(entry.meta).toEqual({ token: '[redacted]', safe: 'ok' });
+  });
+
+  it('normalizes pino numeric levels and message arguments', () => {
+    capturePinoLog([{ apiKey: 'secret' }, 'Backend started'], 30);
+
+    const [entry] = getRecentLogEntries();
+    expect(entry.level).toBe('info');
+    expect(entry.message).toBe('Backend started');
+    expect(entry.meta.apiKey).toBe('[redacted]');
+  });
+});

--- a/tests/realtimeRoutes.test.js
+++ b/tests/realtimeRoutes.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Fastify from 'fastify';
+import logsRoutes from '../src/api/logs.js';
+import transportRoutes from '../src/api/transport.js';
+import { appendLogEntry, clearLogEntries } from '../src/realtime/logBus.js';
+
+describe('realtime API routes', () => {
+  beforeEach(() => clearLogEntries());
+
+  it('returns recent logs for the live logs page', async () => {
+    const app = Fastify({ logger: false });
+    await app.register(logsRoutes);
+    appendLogEntry({ level: 'warn', message: 'QR waiting' });
+
+    const res = await app.inject({ method: 'GET', url: '/api/logs?limit=10' });
+    const body = JSON.parse(res.body);
+
+    expect(res.statusCode).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].message).toBe('QR waiting');
+
+    await app.close();
+  });
+
+  it('regenerates Baileys QR login through the transport manager', async () => {
+    const app = Fastify({ logger: false });
+    const regenerateLogin = vi.fn().mockResolvedValue({ success: true, data: { status: { status: 'connecting' } } });
+
+    await app.register(transportRoutes, {
+      config: { whatsapp: { mode: 'baileys' } },
+      transportManager: { regenerateLogin },
+    });
+
+    const res = await app.inject({ method: 'POST', url: '/api/transport/qr/regenerate' });
+    const body = JSON.parse(res.body);
+
+    expect(res.statusCode).toBe(200);
+    expect(body.success).toBe(true);
+    expect(regenerateLogin).toHaveBeenCalledTimes(1);
+
+    await app.close();
+  });
+
+  it('rejects QR regeneration outside Baileys mode', async () => {
+    const app = Fastify({ logger: false });
+    await app.register(transportRoutes, {
+      config: { whatsapp: { mode: 'cloud_api' } },
+      transportManager: { regenerateLogin: vi.fn() },
+    });
+
+    const res = await app.inject({ method: 'POST', url: '/api/transport/qr/regenerate' });
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body).success).toBe(false);
+
+    await app.close();
+  });
+});

--- a/web/src/api/client.js
+++ b/web/src/api/client.js
@@ -129,3 +129,13 @@ export function editOutgoingMessage(id, content) {
 export function deleteOutgoingMessage(id) {
   return request(`/outgoing/${encodeURIComponent(id)}`, { method: 'DELETE' }).then(d => d.data);
 }
+
+// ── WhatsApp QR login ─────────────────────────────────────────────────
+export function regenerateQrLogin() {
+  return request('/transport/qr/regenerate', { method: 'POST' }).then(d => d.data);
+}
+
+// ── Live logs ──────────────────────────────────────────────────────────
+export function getLogs(limit = 200) {
+  return request(`/logs?limit=${encodeURIComponent(limit)}`).then(d => d.data);
+}

--- a/web/src/components/LogsView.jsx
+++ b/web/src/components/LogsView.jsx
@@ -1,28 +1,85 @@
-import { useState, useCallback } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getLogs } from '../api/client.js';
 import { useSocket } from '../hooks/useSocket.js';
+
+const MAX_LOGS = 200;
+
+function normalizeEntry(entry) {
+  return {
+    id: entry?.id || `${entry?.timestamp || Date.now()}-${entry?.message || 'log'}`,
+    timestamp: entry?.timestamp || new Date().toISOString(),
+    level: entry?.level || 'info',
+    message: entry?.message || 'Log event',
+  };
+}
+
+function mergeLogs(previous, incoming) {
+  const seen = new Set(previous.map((entry) => entry.id));
+  const next = [...previous];
+
+  for (const raw of incoming) {
+    const entry = normalizeEntry(raw);
+    if (seen.has(entry.id)) continue;
+    seen.add(entry.id);
+    next.push(entry);
+  }
+
+  return next.slice(-MAX_LOGS);
+}
 
 export default function LogsView() {
   const [logs, setLogs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const entriesRef = useRef(null);
+
+  const loadLogs = useCallback(async () => {
+    try {
+      setError('');
+      const data = await getLogs(MAX_LOGS);
+      setLogs((prev) => mergeLogs(prev, Array.isArray(data) ? data : []));
+    } catch (err) {
+      setError(err.message || 'Failed to load logs.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadLogs();
+    const interval = setInterval(loadLogs, 5000);
+    return () => clearInterval(interval);
+  }, [loadLogs]);
 
   useSocket('log:entry', useCallback((entry) => {
-    setLogs(prev => {
-      const next = [...prev, entry];
-      // Keep last 200 entries
-      return next.length > 200 ? next.slice(-200) : next;
-    });
+    setLogs((prev) => mergeLogs(prev, [entry]));
   }, []));
 
+  useEffect(() => {
+    entriesRef.current?.scrollTo({ top: entriesRef.current.scrollHeight, behavior: 'smooth' });
+  }, [logs.length]);
+
+  // From raw data to real impact.
   return (
     <div className="logs-view">
-      <h3>Live Logs</h3>
-      {logs.length === 0 ? (
-        <div className="logs-empty">
-          No log entries received yet. Logs appear here in real-time when the backend emits them.
+      <div className="logs-header">
+        <div>
+          <h3>Live Logs</h3>
+          <p>Backend log stream with socket updates and polling fallback.</p>
         </div>
+        <button type="button" onClick={loadLogs} disabled={loading}>Refresh</button>
+      </div>
+
+      {loading && logs.length === 0 ? (
+        <div className="logs-state">Loading logs…</div>
+      ) : error ? (
+        <div className="logs-state logs-error" role="alert">{error}</div>
+      ) : logs.length === 0 ? (
+        <div className="logs-state logs-empty">No log entries yet. Start the backend or trigger an action to see live events.</div>
       ) : (
-        <div className="logs-entries">
-          {logs.map((entry, i) => (
-            <div key={i} className={`log-entry log-${entry.level || 'info'}`}>
+        <div className="logs-entries" ref={entriesRef}>
+          {logs.map((entry) => (
+            <div key={entry.id} className={`log-entry log-${entry.level || 'info'}`}>
               <span className="log-time">
                 {entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString() : ''}
               </span>

--- a/web/src/components/QRCodeDisplay.jsx
+++ b/web/src/components/QRCodeDisplay.jsx
@@ -1,40 +1,70 @@
-import { useQRCode } from '../hooks/useStatus.js';
+import { useCallback, useEffect, useState } from 'react';
+import { regenerateQrLogin } from '../api/client.js';
+import { useQRCode, useStatus } from '../hooks/useStatus.js';
+import { clearQrLoginArtifacts } from '../utils/loginCleanup.js';
 
 export default function QRCodeDisplay({ whatsappStatus }) {
-  const { qrDataUrl } = useQRCode();
+  const { qrDataUrl, clearQrDataUrl } = useQRCode();
+  const { refresh } = useStatus();
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState('');
 
   const status = whatsappStatus?.status;
   const mode = whatsappStatus?.mode;
 
-  // Only show QR section for Baileys mode
+  useEffect(() => {
+    clearQrLoginArtifacts();
+    clearQrDataUrl();
+  }, [clearQrDataUrl]);
+
+  const handleRegenerate = useCallback(async () => {
+    setGenerating(true);
+    setError('');
+    clearQrLoginArtifacts();
+    clearQrDataUrl();
+
+    try {
+      await regenerateQrLogin();
+      await refresh();
+    } catch (err) {
+      setError(err.message || 'QR generation failed.');
+    } finally {
+      setGenerating(false);
+    }
+  }, [clearQrDataUrl, refresh]);
+
+  // AnomAI: Click. Run. Learn. AnomAI.
   if (mode !== 'baileys') return null;
 
-  if (status === 'connected') {
-    return (
-      <div className="qr-display">
-        <h3>WhatsApp (Baileys)</h3>
-        <div className="qr-connected">✓ Connected</div>
-      </div>
-    );
-  }
-
-  if (status === 'waiting_for_qr' && qrDataUrl) {
-    return (
-      <div className="qr-display">
-        <h3>WhatsApp (Baileys)</h3>
-        <p>Scan this QR code with WhatsApp on your phone:</p>
-        <img src={qrDataUrl} alt="WhatsApp QR Code" className="qr-image" />
-      </div>
-    );
-  }
+  const showQr = status === 'waiting_for_qr' && qrDataUrl && !generating;
 
   return (
     <div className="qr-display">
       <h3>WhatsApp (Baileys)</h3>
-      <div className="qr-status">Status: {status || 'unknown'}</div>
-      {whatsappStatus?.details && (
-        <div className="qr-details">{whatsappStatus.details}</div>
+      <p className="qr-subtitle">Scan a fresh QR code or regenerate it if the login attempt looks stale.</p>
+
+      {status === 'connected' ? (
+        <div className="qr-connected">✓ Connected</div>
+      ) : showQr ? (
+        <div className="qr-panel">
+          <p>Scan this QR code with WhatsApp on your phone:</p>
+          <img src={qrDataUrl} alt="WhatsApp QR Code" className="qr-image" />
+        </div>
+      ) : (
+        <div className="qr-status-card">
+          <div className="qr-status">Status: {generating ? 'generating fresh QR…' : (status || 'unknown')}</div>
+          {whatsappStatus?.details && !generating && (
+            <div className="qr-details">{whatsappStatus.details}</div>
+          )}
+        </div>
       )}
+
+      {generating && <div className="qr-loading">Generating a fresh QR and clearing stale login state…</div>}
+      {error && <div className="qr-error" role="alert">{error}</div>}
+
+      <button className="qr-regenerate-button" type="button" onClick={handleRegenerate} disabled={generating}>
+        {generating ? 'Generating…' : 'Generoi QR uudelleen / Regenerate QR'}
+      </button>
     </div>
   );
 }

--- a/web/src/hooks/useStatus.js
+++ b/web/src/hooks/useStatus.js
@@ -35,6 +35,7 @@ export function useStatus() {
 
 export function useQRCode() {
   const [qrDataUrl, setQrDataUrl] = useState(null);
+  const clearQrDataUrl = useCallback(() => setQrDataUrl(null), []);
 
   useSocket('transport:qr', useCallback(({ qrDataUrl: url }) => {
     setQrDataUrl(url);
@@ -47,5 +48,5 @@ export function useQRCode() {
     }
   }, []));
 
-  return { qrDataUrl };
+  return { qrDataUrl, clearQrDataUrl };
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -705,6 +705,13 @@ input, textarea, select {
 
 .qr-display h3 { margin-bottom: 12px; }
 .qr-display p { color: var(--text-muted); margin-bottom: 16px; }
+.qr-subtitle { max-width: 560px; margin: 0 auto 20px; }
+.qr-panel, .qr-status-card { margin: 0 auto 18px; max-width: 520px; }
+.qr-loading { color: var(--accent); padding: 12px; }
+.qr-error { color: var(--red); padding: 12px; }
+.qr-regenerate-button { margin-top: 16px; padding: 10px 16px; border: 1px solid var(--accent); border-radius: var(--radius); color: var(--text); background: rgba(59, 130, 246, 0.12); }
+.qr-regenerate-button:hover:not(:disabled) { background: rgba(59, 130, 246, 0.22); }
+.qr-regenerate-button:disabled { opacity: 0.6; cursor: wait; }
 
 .qr-image {
   max-width: 300px;
@@ -731,7 +738,19 @@ input, textarea, select {
   height: 100%;
 }
 
-.logs-view h3 { margin-bottom: 12px; }
+.logs-view h3 { margin-bottom: 6px; }
+.logs-header { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 12px; }
+.logs-header p { color: var(--text-muted); font-size: 13px; }
+.logs-header button { padding: 8px 12px; border: 1px solid var(--border); border-radius: var(--radius); }
+.logs-state {
+  color: var(--text-muted);
+  padding: 24px;
+  text-align: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
+}
+.logs-error { color: var(--red); }
 
 .logs-empty {
   color: var(--text-muted);
@@ -743,10 +762,15 @@ input, textarea, select {
   font-family: 'Consolas', 'Courier New', monospace;
   font-size: 12px;
   line-height: 1.6;
+  max-height: calc(100vh - 220px);
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
 }
 
 .log-entry {
-  padding: 2px 4px;
+  padding: 4px 8px;
   border-bottom: 1px solid var(--border);
   display: flex;
   gap: 8px;

--- a/web/src/utils/loginCleanup.js
+++ b/web/src/utils/loginCleanup.js
@@ -1,0 +1,46 @@
+const QR_LOGIN_KEY_PATTERNS = [
+  /^anomchatbot-(qr|login|auth|session|baileys|whatsapp)/i,
+  /^(qr|login|auth|session|baileys|whatsapp)[._:-]?/i,
+  /(qr|baileys).*login/i,
+];
+
+function isQrLoginKey(key) {
+  return QR_LOGIN_KEY_PATTERNS.some((pattern) => pattern.test(key));
+}
+
+function clearStorage(storage) {
+  if (!storage) return [];
+  const removed = [];
+  for (let index = storage.length - 1; index >= 0; index -= 1) {
+    const key = storage.key(index);
+    if (!key || !isQrLoginKey(key)) continue;
+    storage.removeItem(key);
+    removed.push(key);
+  }
+  return removed;
+}
+
+function clearCookies() {
+  if (typeof document === 'undefined' || !document.cookie) return [];
+  const removed = [];
+  const cookies = document.cookie.split(';').map((item) => item.trim()).filter(Boolean);
+
+  for (const cookie of cookies) {
+    const [rawName] = cookie.split('=');
+    const name = decodeURIComponent(rawName || '').trim();
+    if (!name || !isQrLoginKey(name)) continue;
+    document.cookie = `${encodeURIComponent(name)}=; Max-Age=0; path=/; SameSite=Lax`;
+    removed.push(name);
+  }
+
+  return removed;
+}
+
+// Engineered for autonomy, designed for humans.
+export function clearQrLoginArtifacts() {
+  return {
+    localStorage: clearStorage(globalThis.localStorage),
+    sessionStorage: clearStorage(globalThis.sessionStorage),
+    cookies: clearCookies(),
+  };
+}


### PR DESCRIPTION
### Motivation
- Users experienced ghost/stale WhatsApp login attempts (Baileys) and the GUI had no way to force a fresh QR; logs page stayed empty and `start.bat` printed noisy raw output.  
- Provide a safe, scoped way to invalidate a QR/login attempt (backend + browser cleanup) so old auth artifacts do not interfere with new scans.  
- Offer a reliable live-logs UX (recoverable after refresh) and make the Windows start script clearer for normal users.  
- Less noise. More signal. AnomFIN.

### Description
- QR regeneration: added a backend route `POST /api/transport/qr/regenerate` (`src/api/transport.js`) and a transport-level `regenerateLogin()` flow wired into the transport manager (`src/transport/manager.js`) which closes the active Baileys socket, clears the configured auth directory, reloads Baileys and reconnects to force a fresh QR (`src/transport/whatsappBaileys.js`).
- Browser cleanup + UI: added `web/src/utils/loginCleanup.js` to remove only QR/login-related keys and cookies, a visible bilingual regenerate button and state handling in the QR UI (`web/src/components/QRCodeDisplay.jsx`), and made `useQRCode()` expose a `clearQrDataUrl()` helper (`web/src/hooks/useStatus.js`).
- Live logs: implemented a redacting in-memory ring buffer and Socket.IO emitter (`src/realtime/logBus.js`), an HTTP recovery endpoint `GET /api/logs` (`src/api/logs.js`), and hooked Fastify logger into the bus (`src/server.js`) so backend log events are emitted to clients.
- Logs UI: made `web/src/components/LogsView.jsx` load recent logs from `/api/logs`, subscribe to `log:entry` Socket.IO events, poll as a fallback, and show loading/empty/error states with timestamps/levels and auto-scroll.
- start.bat UX: rewrote `start.bat` to present dependency checks, sections (`Checking dependencies`, `Starting backend`, `Starting web UI`, `Local URLs`, `Error instructions`), keep the same `node src/index.js` behavior and preserve Windows-friendliness.
- Minor: CSS and copy updates to support new UI elements (`web/src/index.css`), client helpers `regenerateQrLogin()`/`getLogs()` (`web/src/api/client.js`), and small tests to cover log bus and realtime routes (`tests/logBus.test.js`, `tests/realtimeRoutes.test.js`).

### Testing
- Ran unit & integration tests with `npm test` (Vitest) and all tests passed: `190 tests, 190 passed` (including new `tests/logBus.test.js` and `tests/realtimeRoutes.test.js`).
- Built the frontend with `npm run build:web` and verified production build succeeds (Vite build completed).  
- Verified server startup sanity with `node --input-type=module -e "import { createServer } from './src/server.js'; const app = createServer({ logLevel: 'silent' }); await app.ready(); await app.close(); console.log('server-ok');"` which printed `server-ok`.  
- Smoke-checked flows locally: QR regenerate call triggers transport `regenerateLogin()` (tested via new route unit test) and logs are emitted to clients and available via `GET /api/logs` (tested via route).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbed32f8208332b92dfe3bd5079e66)